### PR TITLE
Update werkzeug to 2.0.1 to fix a CVE

### DIFF
--- a/recipe/0003-Use-Werkzeug-2.0.1-to-fix-a-CVE.patch
+++ b/recipe/0003-Use-Werkzeug-2.0.1-to-fix-a-CVE.patch
@@ -1,0 +1,32 @@
+From 720f97f0be7075d7d4938e3aaa585bcfaf53efb3 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Mon, 25 Oct 2021 06:11:27 -0400
+Subject: [PATCH] Use Werkzeug 2.0.1 to fix a CVE
+
+---
+ third_party/python.bzl | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/third_party/python.bzl b/third_party/python.bzl
+index 854a5c5a..3dc07dcd 100644
+--- a/third_party/python.bzl
++++ b/third_party/python.bzl
+@@ -69,11 +69,11 @@ def tensorboard_python_workspace():
+     http_archive(
+         name = "org_pocoo_werkzeug",
+         urls = [
+-            "http://mirror.tensorflow.org/files.pythonhosted.org/packages/59/2d/b24bab64b409e22f026fee6705b035cb0698399a7b69449c49442b30af47/Werkzeug-0.15.4.tar.gz",
+-            "https://files.pythonhosted.org/packages/59/2d/b24bab64b409e22f026fee6705b035cb0698399a7b69449c49442b30af47/Werkzeug-0.15.4.tar.gz",
++            "http://mirror.tensorflow.org/files.pythonhosted.org/packages/e3/bd/a49e5f756b2f29010b5be321fe02478660dbf8fefea3f078493c86011b5f/Werkzeug-2.0.1.tar.gz",
++            "https://files.pythonhosted.org/packages/e3/bd/a49e5f756b2f29010b5be321fe02478660dbf8fefea3f078493c86011b5f/Werkzeug-2.0.1.tar.gz",
+         ],
+-        strip_prefix = "Werkzeug-0.15.4",
+-        sha256 = "a0b915f0815982fb2a09161cb8f31708052d0951c3ba433ccc5e1aa276507ca6",
++        strip_prefix = "Werkzeug-2.0.1",
++        sha256 = "1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42",
+         build_file = str(Label("//third_party:werkzeug.BUILD")),
+     )
+ 
+-- 
+2.23.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
     - 0001-Updated-rules_nodejs-for-PPC.patch   # [ppc64le]
     - 0002-CVE-2019-1010266.patch
     - 0005-PSIRT-PVR0214103-for-bleach.patch
+    - 0003-Use-Werkzeug-2.0.1-to-fix-a-CVE.patch
 
 build:
-  number: 7
+  number: 8
   noarch: python
   string: py_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   # Make sure there is no tensorboard entry point in the tensorflow-{gpu-,}base


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Updates werkzeug to 2.0.1 to fix a CVE reported for 1.* which is fixed in versions >=2.0.0. Anaconda has 2.0.1 as the latest version of werkzeug available.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
